### PR TITLE
Add PDF export option and align saved dates

### DIFF
--- a/AttariClass.html
+++ b/AttariClass.html
@@ -312,12 +312,31 @@
     });
 
     // History stream & filters
-    let unsub=null, allRows=[], currentReportRows=[];
+    let unsub=null, historyRows=[], currentReportRows=[];
     let reportRequestToken=0;
     let jsPdfModulePromise=null;
-    function startHistoryStream(){ if(unsub)unsub(); const q=query(notesCol,orderBy('date','desc'),qLimit(200)); unsub=onSnapshot(q,(snap)=>{allRows=snap.docs.map(d=>d.data()); applyFilters(); renderMonthlyReport();}); }
-    function applyFilters(){const s=filterStudent.value;const d=filterDate.value;let list=allRows;if(s)list=list.filter(r=>r.student===s);if(d)list=list.filter(r=>r.date===d);renderHistory(list);renderMonthlyReport();}
+    function startHistoryStream(){ if(unsub)unsub(); const q=query(notesCol,orderBy('date','desc'),qLimit(200)); unsub=onSnapshot(q,(snap)=>{historyRows=snap.docs.map(d=>({id:d.id,...d.data()})); applyFilters(); renderMonthlyReport();}); }
+    function applyFilters(){const s=filterStudent.value;const d=filterDate.value;let list=historyRows;if(s)list=list.filter(r=>r.student===s);if(d)list=list.filter(r=>r.date===d);renderHistory(list);renderMonthlyReport();}
     filterStudent.addEventListener('change',applyFilters); filterDate.addEventListener('change',applyFilters); document.getElementById('clearFilters').addEventListener('click',()=>{filterStudent.value='';filterDate.value='';applyFilters();}); document.getElementById('reload').addEventListener('click',applyFilters);
+    async function fetchMonthlyRows(student,range){
+      const baseConstraints=[where('date','>=',range.start),where('date','<=',range.end),orderBy('date','asc')];
+      const mapSnap=snap=>snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()}));
+      if(!student){
+        const snap=await getDocs(query(notesCol,...baseConstraints));
+        return mapSnap(snap);
+      }
+      try{
+        const snap=await getDocs(query(notesCol,where('student','==',student),...baseConstraints));
+        return mapSnap(snap);
+      }catch(err){
+        if(err?.code==='failed-precondition'||/index/i.test(err?.message||'')){
+          const snap=await getDocs(query(notesCol,...baseConstraints));
+          return mapSnap(snap).filter(r=>r.student===student);
+        }
+        throw err;
+      }
+    }
+
     reportStudent?.addEventListener('change',renderMonthlyReport);
     reportMonth?.addEventListener('change',renderMonthlyReport);
     reportFormat?.addEventListener('change',updateReportDownloadLabel);
@@ -357,15 +376,12 @@
       reportEmptyText.textContent='Loading report…';
       try{
         const range=getMonthDateRange(monthValue);
-        let rows=[];
-        if(range){
-          const monthQuery=query(notesCol,where('date','>=',range.start),where('date','<=',range.end),orderBy('date','asc'));
-          const snap=await getDocs(monthQuery);
-          if(requestId!==reportRequestToken)return;
-          rows=snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()}));
-        }else{
-          rows=allRows.slice();
+        if(!range){
+          reportEmptyText.textContent='Choose a valid month to view the report.';
+          return;
         }
+        const rows=await fetchMonthlyRows(student,range);
+        if(requestId!==reportRequestToken)return;
         const filtered=rows.filter(r=>r.student===student&&isInMonth(r.date,monthValue));
         if(!filtered.length){
           if(requestId===reportRequestToken){reportEmptyText.textContent=`No entries found for ${student} in ${formatMonthYear(monthValue)}.`;}

--- a/AttariClass.html
+++ b/AttariClass.html
@@ -215,7 +215,7 @@
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
     import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-auth.js";
-    import { getFirestore, collection, doc, setDoc, getDoc, deleteDoc, query, orderBy, limit as qLimit, onSnapshot, serverTimestamp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-firestore.js";
+    import { getFirestore, collection, doc, setDoc, getDoc, getDocs, deleteDoc, query, orderBy, where, limit as qLimit, onSnapshot, serverTimestamp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-firestore.js";
 
     const firebaseConfig = { apiKey:"AIzaSyCTGIoNNey_0GwRxg_85Xv-jEQtQDjzehw", authDomain:"attari-579d2.firebaseapp.com", projectId:"attari-579d2", storageBucket:"attari-579d2.firebasestorage.app", messagingSenderId:"765966619098", appId:"1:765966619098:web:9ab852c4881426472b70e3" };
 
@@ -313,6 +313,7 @@
 
     // History stream & filters
     let unsub=null, allRows=[], currentReportRows=[];
+    let reportRequestToken=0;
     let jsPdfModulePromise=null;
     function startHistoryStream(){ if(unsub)unsub(); const q=query(notesCol,orderBy('date','desc'),qLimit(200)); unsub=onSnapshot(q,(snap)=>{allRows=snap.docs.map(d=>d.data()); applyFilters(); renderMonthlyReport();}); }
     function applyFilters(){const s=filterStudent.value;const d=filterDate.value;let list=allRows;if(s)list=list.filter(r=>r.student===s);if(d)list=list.filter(r=>r.date===d);renderHistory(list);renderMonthlyReport();}
@@ -337,7 +338,7 @@
             <button class='px-2 py-1 text-xs rounded-lg ring-1 ring-red-300 text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20' data-action='delete' data-id='${r.id}'>Delete</button>
           </td>`;historyBody.appendChild(tr);}); countInfo.textContent=`${rows.length} note${rows.length===1?'':'s'} shown`;}
 
-    function renderMonthlyReport(){
+    async function renderMonthlyReport(){
       if(!reportStudent||!reportMonth)return;
       const student=reportStudent.value;
       const monthValue=reportMonth.value;
@@ -352,10 +353,27 @@
       reportEmpty.classList.remove('hidden');
       if(!student){reportEmptyText.textContent='Select a student to see their monthly report.';return;}
       if(!monthValue){reportEmptyText.textContent='Choose a month to view the report.';return;}
-      const filtered=allRows.filter(r=>r.student===student&&isInMonth(r.date,monthValue));
-      if(!filtered.length){reportEmptyText.textContent=`No entries found for ${student} in ${formatMonthYear(monthValue)}.`;return;}
-      const sorted=filtered.slice().sort((a,b)=>{const da=parseDate(a.date);const db=parseDate(b.date);if(da&&db)return da-db;return (a.date||'').localeCompare(b.date||'');});
-      reportBody.innerHTML=sorted.map(r=>`
+      const requestId=++reportRequestToken;
+      reportEmptyText.textContent='Loading report…';
+      try{
+        const range=getMonthDateRange(monthValue);
+        let rows=[];
+        if(range){
+          const monthQuery=query(notesCol,where('date','>=',range.start),where('date','<=',range.end),orderBy('date','asc'));
+          const snap=await getDocs(monthQuery);
+          if(requestId!==reportRequestToken)return;
+          rows=snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()}));
+        }else{
+          rows=allRows.slice();
+        }
+        const filtered=rows.filter(r=>r.student===student&&isInMonth(r.date,monthValue));
+        if(!filtered.length){
+          if(requestId===reportRequestToken){reportEmptyText.textContent=`No entries found for ${student} in ${formatMonthYear(monthValue)}.`;}
+          return;
+        }
+        const sorted=filtered.slice().sort((a,b)=>{const da=parseDate(a.date);const db=parseDate(b.date);if(da&&db)return da-db;return (a.date||'').localeCompare(b.date||'');});
+        if(requestId!==reportRequestToken)return;
+        reportBody.innerHTML=sorted.map(r=>`
           <tr>
             <td class='px-6 py-3 font-medium'>${esc(formatDisplayDate(r.date))}</td>
             <td class='px-6 py-3'>${esc(r.quran||'')}</td>
@@ -364,14 +382,20 @@
             <td class='px-6 py-3'>${esc(r.qamar||'')}</td>
             <td class='px-6 py-3'>${esc(r.anythingElse||'')}</td>
           </tr>`).join('');
-      reportTableWrapper.classList.remove('hidden');
-      reportEmpty.classList.add('hidden');
-      reportInfo.textContent=`${sorted.length} entr${sorted.length===1?'y':'ies'} for ${student} in ${formatMonthYear(monthValue)}.`;
-      if(reportDownload){
-        reportDownload.disabled=false;
-        updateReportDownloadLabel();
+        reportTableWrapper.classList.remove('hidden');
+        reportEmpty.classList.add('hidden');
+        reportInfo.textContent=`${sorted.length} entr${sorted.length===1?'y':'ies'} for ${student} in ${formatMonthYear(monthValue)}.`;
+        if(reportDownload){
+          reportDownload.disabled=false;
+          updateReportDownloadLabel();
+        }
+        currentReportRows=sorted;
+      }catch(err){
+        if(requestId!==reportRequestToken)return;
+        console.error(err);
+        reportEmptyText.textContent='Unable to load monthly report.';
+        showToast('Failed to load monthly report','error');
       }
-      currentReportRows=sorted;
     }
 
     async function downloadMonthlyReport(){
@@ -382,6 +406,7 @@
       const format=(reportFormat?.value||'csv').toLowerCase();
       reportDownload.dataset.loading='true';
       reportDownload.disabled=true;
+      updateReportDownloadLabel();
       try{
         if(format==='pdf'){
           await downloadMonthlyPdf(student,monthValue);
@@ -459,6 +484,10 @@
 
     function updateReportDownloadLabel(){
       if(!reportDownload)return;
+      if(reportDownload.dataset.loading){
+        reportDownload.textContent='Preparing…';
+        return;
+      }
       const format=(reportFormat?.value||'csv').toUpperCase();
       reportDownload.textContent=`⬇️ Download ${format}`;
     }
@@ -485,8 +514,9 @@
     function extractDateFromId(id){if(!id)return null;const match=String(id).match(/^(\d{4}-\d{2}-\d{2})_/);return match?match[1]:null;}
     function parseDate(input){if(!input&&input!==0)return null;if(input instanceof Date)return isNaN(input.getTime())?null:input;if(typeof input?.toDate==='function'){const date=input.toDate();return date instanceof Date&&!isNaN(date.getTime())?date:null;}const str=String(input).trim();const iso=str.match(/^(\d{4})-(\d{2})-(\d{2})$/);if(iso){const[,y,m,d]=iso;const date=new Date(Number(y),Number(m)-1,Number(d));return isNaN(date.getTime())?null:date;}const slash=str.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);if(slash){const[,d,m,y]=slash;const date=new Date(Number(y),Number(m)-1,Number(d));return isNaN(date.getTime())?null:date;}const parsed=new Date(str);return isNaN(parsed.getTime())?null:parsed;}
     function toLocalISODate(value){const date=value instanceof Date?value:parseDate(value);if(!date)return '';const year=date.getFullYear();const month=String(date.getMonth()+1).padStart(2,'0');const day=String(date.getDate()).padStart(2,'0');return `${year}-${month}-${day}`;}
-    function formatDisplayDate(value){const date=value instanceof Date?value:parseDate(value);if(!date)return value??'';const day=String(date.getDate()).padStart(2,'0');const month=MONTH_LABELS[date.getMonth()]||'';const year=date.getFullYear();return month?`${day} ${month} ${year}`:value??'';}
+    function formatDisplayDate(value){const date=value instanceof Date?value:parseDate(value);if(!date)return value??'';const day=date.getDate();const month=MONTH_LABELS[date.getMonth()]||'';const year=date.getFullYear();return month?`${day} ${month} ${year}`:value??'';}
     function formatMonthYear(monthValue){if(!monthValue)return '';const parts=String(monthValue).split('-');if(parts.length<2)return monthValue;const year=Number(parts[0]);const monthIndex=Number(parts[1])-1;if(Number.isNaN(year)||Number.isNaN(monthIndex)||monthIndex<0||monthIndex>11)return monthValue;const month=MONTH_LABELS[monthIndex]||'';return month?`${month} ${year}`:monthValue;}
+    function getMonthDateRange(monthValue){if(!monthValue)return null;const parts=String(monthValue).split('-');if(parts.length<2)return null;const yearStr=parts[0];const monthNum=Number(parts[1]);const monthIndex=monthNum-1;const year=Number(yearStr);if(Number.isNaN(year)||Number.isNaN(monthIndex)||monthIndex<0||monthIndex>11)return null;const monthStr=String(monthIndex+1).padStart(2,'0');const lastDay=new Date(year,monthIndex+1,0).getDate();const endDay=String(lastDay).padStart(2,'0');return {start:`${yearStr}-${monthStr}-01`,end:`${yearStr}-${monthStr}-${endDay}`};}
     function isInMonth(dateValue,monthValue){const date=parseDate(dateValue);if(!date||!monthValue)return false;const [yearStr,monthStr]=String(monthValue).split('-');const year=Number(yearStr);const month=Number(monthStr);if(Number.isNaN(year)||Number.isNaN(month))return false;return date.getFullYear()===year&&date.getMonth()+1===month;}
     function toCsvValue(value){const str=(value??'').toString().replace(/"/g,'""').replace(/\r?\n/g,' ');return `"${str}"`;}
     function esc(s){return (s??'').toString().replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c]))}

--- a/AttariClass.html
+++ b/AttariClass.html
@@ -156,6 +156,51 @@
             </div>
           </div>
         </section>
+
+        <!-- Monthly Reports Card -->
+        <section class="xl:col-span-5">
+          <div class="glass bg-white/70 dark:bg-slate-900/70 rounded-3xl shadow-2xl border border-white/20 dark:border-slate-700/30">
+            <div class="p-6 md:p-8 border-b border-slate-200/50 dark:border-slate-700/50 flex flex-col lg:flex-row gap-4 lg:items-center lg:justify-between">
+              <div>
+                <h2 class="text-2xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-emerald-600 to-blue-600">🗓️ Monthly Reports</h2>
+                <p class="text-sm text-slate-600 dark:text-slate-400">Review per-student progress and export it as a CSV or PDF file.</p>
+              </div>
+              <div class="flex flex-wrap gap-3 items-center">
+                <select id="reportStudent" class="rounded-xl bg-slate-50/80 dark:bg-slate-800/80 border-2 border-slate-200/60 dark:border-slate-700/60 px-4 py-2 text-sm font-medium focus:border-emerald-500">
+                  <option value="" disabled selected>Select a student…</option>
+                </select>
+                <input id="reportMonth" type="month" class="rounded-xl bg-slate-50/80 dark:bg-slate-800/80 border-2 border-slate-200/60 dark:border-slate-700/60 px-4 py-2 text-sm font-medium focus:border-emerald-500" />
+                <select id="reportFormat" class="rounded-xl bg-slate-50/80 dark:bg-slate-800/80 border-2 border-slate-200/60 dark:border-slate-700/60 px-4 py-2 text-sm font-medium focus:border-emerald-500">
+                  <option value="csv" selected>CSV</option>
+                  <option value="pdf">PDF</option>
+                </select>
+                <button id="reportDownload" type="button" class="px-4 py-2 rounded-xl bg-gradient-to-r from-emerald-500 to-teal-500 text-white font-medium shadow-lg disabled:opacity-50 disabled:cursor-not-allowed" disabled>⬇️ Download CSV</button>
+              </div>
+            </div>
+            <div class="p-6 md:p-8 space-y-6">
+              <div id="reportInfo" class="text-sm text-slate-600 dark:text-slate-400"></div>
+              <div id="reportTableWrapper" class="overflow-x-auto custom-scrollbar hidden">
+                <table class="min-w-full text-left text-sm">
+                  <thead class="bg-slate-100/80 dark:bg-slate-800/80">
+                    <tr>
+                      <th class="px-6 py-3 font-semibold">📅 Date</th>
+                      <th class="px-6 py-3 font-semibold">📖 Quran</th>
+                      <th class="px-6 py-3 font-semibold">🕌 Surah</th>
+                      <th class="px-6 py-3 font-semibold">🤲 Salah</th>
+                      <th class="px-6 py-3 font-semibold">🌙 Qamar</th>
+                      <th class="px-6 py-3 font-semibold">💭 Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody id="reportBody" class="divide-y divide-slate-200/50 dark:divide-slate-700/50"></tbody>
+                </table>
+              </div>
+              <div id="reportEmpty" class="text-center text-slate-500 py-10">
+                <div class="text-5xl mb-3">📂</div>
+                <p id="reportEmptyText">Select a student to see their monthly report.</p>
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
 
       <footer class="mt-12 text-center">
@@ -199,6 +244,7 @@
 
     // Students and elements
     const students=["Siyaam Azar","Hussain Ali","Hamza Razzaq","Subhan Hussain","Milad Raza","Murtaza Arfan","Zeeshan Hussain","Mohammed Subhan Ramzan","Onees Usman","Mohammed Hassan Hussain","Ali Hussein"];
+    const MONTH_LABELS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     const inputs={student:document.getElementById('student'),quran:document.getElementById('quran'),surah:document.getElementById('surah'),laws:document.getElementById('laws'),qamar:document.getElementById('qamar'),anything:document.getElementById('anything')};
     const filterStudent=document.getElementById('filterStudent');
     const filterDate=document.getElementById('filterDate');
@@ -211,12 +257,24 @@
     const saveText=document.getElementById('saveText');
     const saveSpinner=document.getElementById('saveSpinner');
     const saveStatus=document.getElementById('saveStatus');
+    const reportStudent=document.getElementById('reportStudent');
+    const reportMonth=document.getElementById('reportMonth');
+    const reportFormat=document.getElementById('reportFormat');
+    const reportBody=document.getElementById('reportBody');
+    const reportTableWrapper=document.getElementById('reportTableWrapper');
+    const reportEmpty=document.getElementById('reportEmpty');
+    const reportEmptyText=document.getElementById('reportEmptyText');
+    const reportInfo=document.getElementById('reportInfo');
+    const reportDownload=document.getElementById('reportDownload');
 
     // Populate selects
-    function populateStudents(){inputs.student.innerHTML='<option value="" disabled selected>Choose a student…</option>';filterStudent.innerHTML='<option value="">All students</option>';students.forEach(n=>{const o=document.createElement('option');o.value=n;o.textContent=n;inputs.student.appendChild(o);const o2=document.createElement('option');o2.value=o.value;o2.textContent=n;filterStudent.appendChild(o2);});}
+    function populateStudents(){inputs.student.innerHTML='<option value="" disabled selected>Choose a student…</option>';filterStudent.innerHTML='<option value="">All students</option>';reportStudent.innerHTML='<option value="" disabled selected>Select a student…</option>';students.forEach(n=>{const o=document.createElement('option');o.value=n;o.textContent=n;inputs.student.appendChild(o);const o2=document.createElement('option');o2.value=o.value;o2.textContent=n;filterStudent.appendChild(o2);const o3=document.createElement('option');o3.value=o.value;o3.textContent=n;reportStudent.appendChild(o3);});}
     populateStudents();
 
-    const today=new Date().toISOString().slice(0,10); document.getElementById('todayDisplay').textContent=today;
+    const now=new Date();
+    const todayKey=toLocalISODate(now);
+    document.getElementById('todayDisplay').textContent=formatDisplayDate(todayKey);
+    if(reportMonth)reportMonth.value=`${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}`;
 
     const CLASS_ID='Attari';
     const notesCol=collection(doc(db,'classes',CLASS_ID),'notes');
@@ -233,17 +291,42 @@
     cancelEditBtn.addEventListener('click',()=>setEditMode(null));
 
     // Save/Update
-    document.getElementById('notesForm').addEventListener('submit',async(e)=>{e.preventDefault();const student=inputs.student.value;if(!student){saveStatus.textContent='Choose a student';return}saveSpinner.classList.remove('hidden');const id=editingKey||noteId(today,student);const ref=doc(notesCol,id);const payload={id,date:today,student,quran:inputs.quran.value.trim(),surah:inputs.surah.value.trim(),lawsOfSalah:inputs.laws.value.trim(),qamar:inputs.qamar.value.trim(),anythingElse:inputs.anything.value.trim(),updatedAt:serverTimestamp(),ownerUid:auth.currentUser?.uid||null};const snap=await getDoc(ref);if(!snap.exists())payload.createdAt=serverTimestamp();await setDoc(ref,payload,{merge:true});saveSpinner.classList.add('hidden');showToast(editingKey?'Updated ✓':'Saved ✓','success');saveStatus.textContent=editingKey?'Updated ✅':'Saved ✅';setTimeout(()=>saveStatus.textContent='',1200);setEditMode(null)});
+    document.getElementById('notesForm').addEventListener('submit',async(e)=>{
+      e.preventDefault();
+      const student=inputs.student.value;
+      if(!student){saveStatus.textContent='Choose a student';return}
+      saveSpinner.classList.remove('hidden');
+      const defaultDate=toLocalISODate(new Date());
+      const entryDate=editingKey?extractDateFromId(editingKey)||defaultDate:defaultDate;
+      const id=editingKey||noteId(entryDate,student);
+      const ref=doc(notesCol,id);
+      const payload={id,date:entryDate,student,quran:inputs.quran.value.trim(),surah:inputs.surah.value.trim(),lawsOfSalah:inputs.laws.value.trim(),qamar:inputs.qamar.value.trim(),anythingElse:inputs.anything.value.trim(),updatedAt:serverTimestamp(),ownerUid:auth.currentUser?.uid||null};
+      const snap=await getDoc(ref);
+      if(!snap.exists())payload.createdAt=serverTimestamp();
+      await setDoc(ref,payload,{merge:true});
+      saveSpinner.classList.add('hidden');
+      showToast(editingKey?'Updated ✓':'Saved ✓','success');
+      saveStatus.textContent=editingKey?'Updated ✅':'Saved ✅';
+      setTimeout(()=>saveStatus.textContent='',1200);
+      setEditMode(null);
+    });
 
     // History stream & filters
-    let unsub=null, allRows=[];
-    function startHistoryStream(){ if(unsub)unsub(); const q=query(notesCol,orderBy('date','desc'),qLimit(200)); unsub=onSnapshot(q,(snap)=>{allRows=snap.docs.map(d=>d.data()); applyFilters();}); }
-    function applyFilters(){const s=filterStudent.value;const d=filterDate.value;let list=allRows;if(s)list=list.filter(r=>r.student===s);if(d)list=list.filter(r=>r.date===d);renderHistory(list);} 
+    let unsub=null, allRows=[], currentReportRows=[];
+    let jsPdfModulePromise=null;
+    function startHistoryStream(){ if(unsub)unsub(); const q=query(notesCol,orderBy('date','desc'),qLimit(200)); unsub=onSnapshot(q,(snap)=>{allRows=snap.docs.map(d=>d.data()); applyFilters(); renderMonthlyReport();}); }
+    function applyFilters(){const s=filterStudent.value;const d=filterDate.value;let list=allRows;if(s)list=list.filter(r=>r.student===s);if(d)list=list.filter(r=>r.date===d);renderHistory(list);renderMonthlyReport();}
     filterStudent.addEventListener('change',applyFilters); filterDate.addEventListener('change',applyFilters); document.getElementById('clearFilters').addEventListener('click',()=>{filterStudent.value='';filterDate.value='';applyFilters();}); document.getElementById('reload').addEventListener('click',applyFilters);
+    reportStudent?.addEventListener('change',renderMonthlyReport);
+    reportMonth?.addEventListener('change',renderMonthlyReport);
+    reportFormat?.addEventListener('change',updateReportDownloadLabel);
+    reportDownload?.addEventListener('click',async()=>{if(reportDownload.disabled)return;await downloadMonthlyReport();});
+    updateReportDownloadLabel();
+    renderMonthlyReport();
 
     function renderHistory(rows){historyBody.innerHTML=''; if(!rows.length){emptyState.classList.remove('hidden');countInfo.textContent='0 notes';return;} emptyState.classList.add('hidden'); rows.forEach(r=>{const tr=document.createElement('tr'); tr.innerHTML=`
-          <td class='px-6 py-3 font-medium'>${r.date}</td>
-          <td class='px-6 py-3'>${r.student}</td>
+          <td class='px-6 py-3 font-medium'>${esc(formatDisplayDate(r.date))}</td>
+          <td class='px-6 py-3'>${esc(r.student||'')}</td>
           <td class='px-6 py-3'>${esc(r.quran||'')}</td>
           <td class='px-6 py-3'>${esc(r.surah||'')}</td>
           <td class='px-6 py-3'>${esc(r.lawsOfSalah||'')}</td>
@@ -254,13 +337,159 @@
             <button class='px-2 py-1 text-xs rounded-lg ring-1 ring-red-300 text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20' data-action='delete' data-id='${r.id}'>Delete</button>
           </td>`;historyBody.appendChild(tr);}); countInfo.textContent=`${rows.length} note${rows.length===1?'':'s'} shown`;}
 
+    function renderMonthlyReport(){
+      if(!reportStudent||!reportMonth)return;
+      const student=reportStudent.value;
+      const monthValue=reportMonth.value;
+      currentReportRows=[];
+      reportBody.innerHTML='';
+      reportInfo.textContent='';
+      if(reportDownload){
+        reportDownload.disabled=true;
+        updateReportDownloadLabel();
+      }
+      reportTableWrapper.classList.add('hidden');
+      reportEmpty.classList.remove('hidden');
+      if(!student){reportEmptyText.textContent='Select a student to see their monthly report.';return;}
+      if(!monthValue){reportEmptyText.textContent='Choose a month to view the report.';return;}
+      const filtered=allRows.filter(r=>r.student===student&&isInMonth(r.date,monthValue));
+      if(!filtered.length){reportEmptyText.textContent=`No entries found for ${student} in ${formatMonthYear(monthValue)}.`;return;}
+      const sorted=filtered.slice().sort((a,b)=>{const da=parseDate(a.date);const db=parseDate(b.date);if(da&&db)return da-db;return (a.date||'').localeCompare(b.date||'');});
+      reportBody.innerHTML=sorted.map(r=>`
+          <tr>
+            <td class='px-6 py-3 font-medium'>${esc(formatDisplayDate(r.date))}</td>
+            <td class='px-6 py-3'>${esc(r.quran||'')}</td>
+            <td class='px-6 py-3'>${esc(r.surah||'')}</td>
+            <td class='px-6 py-3'>${esc(r.lawsOfSalah||'')}</td>
+            <td class='px-6 py-3'>${esc(r.qamar||'')}</td>
+            <td class='px-6 py-3'>${esc(r.anythingElse||'')}</td>
+          </tr>`).join('');
+      reportTableWrapper.classList.remove('hidden');
+      reportEmpty.classList.add('hidden');
+      reportInfo.textContent=`${sorted.length} entr${sorted.length===1?'y':'ies'} for ${student} in ${formatMonthYear(monthValue)}.`;
+      if(reportDownload){
+        reportDownload.disabled=false;
+        updateReportDownloadLabel();
+      }
+      currentReportRows=sorted;
+    }
+
+    async function downloadMonthlyReport(){
+      if(!currentReportRows.length||!reportStudent||!reportMonth||!reportDownload)return;
+      const student=reportStudent.value;
+      const monthValue=reportMonth.value;
+      if(!student||!monthValue)return;
+      const format=(reportFormat?.value||'csv').toLowerCase();
+      reportDownload.dataset.loading='true';
+      reportDownload.disabled=true;
+      try{
+        if(format==='pdf'){
+          await downloadMonthlyPdf(student,monthValue);
+        }else{
+          downloadMonthlyCsv(student,monthValue);
+        }
+      }catch(err){
+        console.error(err);
+        showToast('Download failed','error');
+      }finally{
+        if(reportDownload.dataset.loading)delete reportDownload.dataset.loading;
+        const shouldDisable=!currentReportRows.length;
+        reportDownload.disabled=shouldDisable;
+        updateReportDownloadLabel();
+      }
+    }
+
+    function downloadMonthlyCsv(student,monthValue){
+      const rows=[['Date','Student','Quran','Surah','Laws of Salah','Qamar','Notes']];
+      currentReportRows.forEach(r=>{rows.push([formatDisplayDate(r.date),r.student||'',r.quran||'',r.surah||'',r.lawsOfSalah||'',r.qamar||'',r.anythingElse||'']);});
+      const csv=rows.map(row=>row.map(toCsvValue).join(',')).join('\r\n');
+      const blob=new Blob([csv],{type:'text/csv;charset=utf-8;'});
+      const url=URL.createObjectURL(blob);
+      const link=document.createElement('a');
+      link.href=url;
+      link.download=buildReportFilename(student,monthValue,'csv');
+      document.body.appendChild(link);
+      link.click();
+      setTimeout(()=>{URL.revokeObjectURL(url);link.remove();},0);
+      showToast('CSV report downloaded ✓','success');
+    }
+
+    async function downloadMonthlyPdf(student,monthValue){
+      const module=await ensureJsPdf();
+      const jsPdfConstructor=module?.jsPDF||module?.default?.jsPDF||module?.default;
+      if(typeof jsPdfConstructor!=='function')throw new Error('PDF library failed to load');
+      const doc=new jsPdfConstructor({orientation:'portrait',unit:'pt'});
+      const margin=40;
+      const pageHeight=doc.internal.pageSize.getHeight();
+      const maxWidth=doc.internal.pageSize.getWidth()-margin*2;
+      const monthLabel=formatMonthYear(monthValue)||monthValue;
+      let y=margin;
+      doc.setFont('helvetica','bold');
+      doc.setFontSize(18);
+      doc.text('Monthly Report',margin,y);
+      y+=24;
+      doc.setFont('helvetica','normal');
+      doc.setFontSize(12);
+      doc.text(`Student: ${student}`,margin,y);
+      y+=16;
+      doc.text(`Month: ${monthLabel}`,margin,y);
+      y+=24;
+      const lineHeight=14;
+      currentReportRows.forEach((row,index)=>{
+        if(y>pageHeight-margin){doc.addPage();y=margin;}
+        doc.setFont('helvetica','bold');
+        doc.text(`${index+1}. ${formatDisplayDate(row.date)}`,margin,y);
+        y+=lineHeight;
+        doc.setFont('helvetica','normal');
+        const sections=[['Quran',row.quran],['Surah',row.surah],['Laws of Salah',row.lawsOfSalah],['Qamar',row.qamar],['Notes',row.anythingElse]];
+        sections.forEach(([label,value])=>{
+          const text=`• ${label}: ${value||'-'}`;
+          const lines=doc.splitTextToSize(text,Math.max(maxWidth-20,0));
+          lines.forEach(line=>{
+            if(y>pageHeight-margin){doc.addPage();y=margin;}
+            doc.text(line,margin+20,y);
+            y+=lineHeight;
+          });
+        });
+        y+=lineHeight/2;
+      });
+      doc.save(buildReportFilename(student,monthValue,'pdf'));
+      showToast('PDF report downloaded ✓','success');
+    }
+
+    function updateReportDownloadLabel(){
+      if(!reportDownload)return;
+      const format=(reportFormat?.value||'csv').toUpperCase();
+      reportDownload.textContent=`⬇️ Download ${format}`;
+    }
+
+    function buildReportFilename(student,monthValue,extension){
+      const safeStudent=slug(student||'student')||'student';
+      const safeMonth=monthValue||'report';
+      return `${safeStudent}-${safeMonth}-report.${extension}`;
+    }
+
+    function ensureJsPdf(){
+      if(!jsPdfModulePromise){
+        jsPdfModulePromise=import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.es.min.js').catch(err=>{jsPdfModulePromise=null;throw err;});
+      }
+      return jsPdfModulePromise;
+    }
+
     historyBody.addEventListener('click',async(e)=>{const btn=e.target.closest('button'); if(!btn) return; const id=btn.getAttribute('data-id'); if(btn.getAttribute('data-action')==='edit'){const snap=await getDoc(doc(notesCol,id)); if(snap.exists()) setEditMode(snap.data());} else if(btn.getAttribute('data-action')==='delete'){ if(!confirm('Delete this note?')) return; await deleteDoc(doc(notesCol,id)); showToast('Deleted','success'); }});
 
     // Auth gate
     onAuthStateChanged(auth,(user)=>{ if(user){authGate.classList.add('hidden'); appShell.classList.remove('hidden'); whoami.textContent=user.email||user.uid; authStatus.textContent='Online'; dot.className='w-2 h-2 rounded-full bg-emerald-400'; startHistoryStream(); } else { appShell.classList.add('hidden'); authGate.classList.remove('hidden'); whoami.textContent='Not signed in'; authStatus.textContent='Signed out'; dot.className='w-2 h-2 rounded-full bg-amber-400'; }});
 
     // Utils
-    function esc(s){return (s??'').replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c]))}
+    function extractDateFromId(id){if(!id)return null;const match=String(id).match(/^(\d{4}-\d{2}-\d{2})_/);return match?match[1]:null;}
+    function parseDate(input){if(!input&&input!==0)return null;if(input instanceof Date)return isNaN(input.getTime())?null:input;if(typeof input?.toDate==='function'){const date=input.toDate();return date instanceof Date&&!isNaN(date.getTime())?date:null;}const str=String(input).trim();const iso=str.match(/^(\d{4})-(\d{2})-(\d{2})$/);if(iso){const[,y,m,d]=iso;const date=new Date(Number(y),Number(m)-1,Number(d));return isNaN(date.getTime())?null:date;}const slash=str.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);if(slash){const[,d,m,y]=slash;const date=new Date(Number(y),Number(m)-1,Number(d));return isNaN(date.getTime())?null:date;}const parsed=new Date(str);return isNaN(parsed.getTime())?null:parsed;}
+    function toLocalISODate(value){const date=value instanceof Date?value:parseDate(value);if(!date)return '';const year=date.getFullYear();const month=String(date.getMonth()+1).padStart(2,'0');const day=String(date.getDate()).padStart(2,'0');return `${year}-${month}-${day}`;}
+    function formatDisplayDate(value){const date=value instanceof Date?value:parseDate(value);if(!date)return value??'';const day=String(date.getDate()).padStart(2,'0');const month=MONTH_LABELS[date.getMonth()]||'';const year=date.getFullYear();return month?`${day} ${month} ${year}`:value??'';}
+    function formatMonthYear(monthValue){if(!monthValue)return '';const parts=String(monthValue).split('-');if(parts.length<2)return monthValue;const year=Number(parts[0]);const monthIndex=Number(parts[1])-1;if(Number.isNaN(year)||Number.isNaN(monthIndex)||monthIndex<0||monthIndex>11)return monthValue;const month=MONTH_LABELS[monthIndex]||'';return month?`${month} ${year}`:monthValue;}
+    function isInMonth(dateValue,monthValue){const date=parseDate(dateValue);if(!date||!monthValue)return false;const [yearStr,monthStr]=String(monthValue).split('-');const year=Number(yearStr);const month=Number(monthStr);if(Number.isNaN(year)||Number.isNaN(month))return false;return date.getFullYear()===year&&date.getMonth()+1===month;}
+    function toCsvValue(value){const str=(value??'').toString().replace(/"/g,'""').replace(/\r?\n/g,' ');return `"${str}"`;}
+    function esc(s){return (s??'').toString().replace(/[&<>\"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;'}[c]))}
     function showToast(text,type='success'){ toast.textContent=text; toast.className=`notification show ${type}`; setTimeout(()=>{toast.classList.remove('show')},1600); }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- allow teachers to choose CSV or PDF when exporting monthly reports and update the card copy accordingly
- ensure note submissions store local YYYY-MM-DD dates and keep existing entry dates when editing
- add CSV/PDF export helpers with dynamic jsPDF loading plus improved download button state management

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3ba5ca5f8832ea85a8b1b23d1d814